### PR TITLE
Add progress reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.gradle/
 /.idea/
-/build/
+build/
 /repo/
 /.settings/
 /bin/

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation 'de.siegmar:fastcsv:2.0.0'
     implementation 'net.neoforged:srgutils:1.0.0'
     implementation 'org.ow2.asm:asm-commons:9.3'
+    implementation project(':cli-utils')
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,9 @@ allprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'java-library'
     apply plugin: 'net.neoforged.gradleutils'
-    apply plugin: 'com.github.johnrengelman.shadow'
+    if (project.name != 'cli-utils') {
+        apply plugin: 'com.github.johnrengelman.shadow'
+    }
 
     group = 'net.neoforged.installertools'
     java {
@@ -34,10 +36,15 @@ allprojects {
 
     tasks.named('jar', Jar).configure {
         manifest.attributes('Implementation-Version': project.version)
-        manifest.attributes('Main-Class': application.mainClass.get())
+        if (application.mainClass.getOrNull()) {
+            manifest.attributes('Main-Class': application.mainClass.get())
+        }
     }
-    tasks.named('shadowJar', ShadowJar).configure {
-        archiveClassifier = 'fatjar'
+
+    if (project.name != 'cli-utils') {
+        tasks.named('shadowJar', ShadowJar).configure {
+            archiveClassifier = 'fatjar'
+        }
     }
 }
 

--- a/cli-utils/build.gradle
+++ b/cli-utils/build.gradle
@@ -6,3 +6,13 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+publishing {
+    publications.register('mavenJava', MavenPublication) {
+        from components.java
+        pom {
+            name = 'CLI Utils'
+            description = "CLI Utilities for NeoForge's projects"
+        }
+    }
+}

--- a/cli-utils/build.gradle
+++ b/cli-utils/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    testImplementation('org.junit.jupiter:junit-jupiter-api:5.8.2')
+    testImplementation('org.junit.jupiter:junit-jupiter-engine:5.8.2')
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressActionType.java
+++ b/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressActionType.java
@@ -1,0 +1,31 @@
+package net.neoforged.cliutils.progress;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum ProgressActionType {
+    STEP('s', ProgressManager::setStep),
+    PROGRESS('p', (progressManager, value) -> {
+        if (value.endsWith("%")) {
+            progressManager.setPercentageProgress(Double.parseDouble(value.substring(0, value.length() - 1)));
+        } else {
+            progressManager.setProgress(Integer.parseInt(value));
+        }
+    }),
+    MAX_PROGRESS('m', (progressManager, value) -> progressManager.setMaxProgress(Integer.parseInt(value))),
+    INDETERMINATE('i', (progressManager, value) -> progressManager.setIndeterminate(Boolean.parseBoolean(value)));
+
+    public static final Map<Character, ProgressActionType> TYPES = Arrays.stream(values())
+            .collect(Collectors.toMap(val -> val.identifier, Function.identity()));
+
+    public final char identifier;
+    public final BiConsumer<ProgressManager, String> acceptor;
+
+    ProgressActionType(char identifier, BiConsumer<ProgressManager, String> acceptor) {
+        this.identifier = identifier;
+        this.acceptor = acceptor;
+    }
+}

--- a/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressInterceptor.java
+++ b/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressInterceptor.java
@@ -18,33 +18,50 @@ public class ProgressInterceptor extends FilterOutputStream {
         this.manager = manager;
     }
 
+    private StringBuffer current;
+
     @Override
-    public void write(byte[] buf, int off, int len) throws IOException {
-        final String text = new String(Arrays.copyOfRange(buf, off, len), StandardCharsets.UTF_8);
-        final String[] lines = text.split("\r\n|\n");
-        for (final String line : lines) {
-            if (line.startsWith("\033[" + ProgressReporter.MODIFIER_KEY + ";")) {
-                final String[] values = line.substring(FULL_MODIFIER.length()).split(" ", 2);
-                // If not 2, the value's empty, which isn't supported, so ignore
-                if (values.length == 2) {
-                    final String first = values[0];
-                    if (first.length() != 1) {
-                        System.err.println("Invalid progress modifier: " + values[0]);
-                        continue;
-                    }
-
-                    final ProgressActionType action = ProgressActionType.TYPES.get(first.charAt(0));
-                    if (action == null) {
-                        System.err.println("Unknown progress modifier: " + first.charAt(0));
-                        continue;
-                    }
-
-                    action.acceptor.accept(manager, values[1]);
-                }
+    public void write(int b) throws IOException {
+        if (current != null) {
+            if (b == '\n') {
+                processCurrent();
+            } else if (b != '\r') // Ignore CR because Windows is bad
+                current.append((char)b);
+        } else {
+            if (b == '\033') {
+                current = new StringBuffer()
+                        .append((char)b);
             } else {
-                out.write(line.getBytes(StandardCharsets.UTF_8));
-                out.write('\n');
+                out.write(b);
             }
         }
+    }
+
+    private void processCurrent() throws IOException {
+        final String cur = current.toString();
+        if (cur.startsWith(FULL_MODIFIER)) {
+            final String[] values = cur.substring(FULL_MODIFIER.length()).split(" ", 2);
+            // If not 2, the value's empty, which isn't supported, so ignore
+            if (values.length == 2) {
+                final String first = values[0];
+                if (first.length() != 1) {
+                    System.err.println("Invalid progress modifier: " + values[0]);
+                    return;
+                }
+
+                final ProgressActionType action = ProgressActionType.TYPES.get(first.charAt(0));
+                if (action == null) {
+                    System.err.println("Unknown progress modifier: " + first.charAt(0));
+                    return;
+                }
+
+                action.acceptor.accept(manager, values[1]);
+            }
+        } else {
+            out.write(cur.getBytes(StandardCharsets.UTF_8));
+            out.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        }
+
+        current = null;
     }
 }

--- a/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressInterceptor.java
+++ b/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressInterceptor.java
@@ -1,0 +1,50 @@
+package net.neoforged.cliutils.progress;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * Intercepts {@link ProgressActionType} progress manager actions and redirects them to the {@code manager}.
+ */
+public class ProgressInterceptor extends FilterOutputStream {
+    public static final String FULL_MODIFIER = "\033[" + ProgressReporter.MODIFIER_KEY + ";";
+
+    protected final ProgressManager manager;
+    public ProgressInterceptor(OutputStream out, ProgressManager manager) {
+        super(out);
+        this.manager = manager;
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) throws IOException {
+        final String text = new String(Arrays.copyOfRange(buf, off, len), StandardCharsets.UTF_8);
+        final String[] lines = text.split("\r\n|\n");
+        for (final String line : lines) {
+            if (line.startsWith("\033[" + ProgressReporter.MODIFIER_KEY + ";")) {
+                final String[] values = line.substring(FULL_MODIFIER.length()).split(" ", 2);
+                // If not 2, the value's empty, which isn't supported, so ignore
+                if (values.length == 2) {
+                    final String first = values[0];
+                    if (first.length() != 1) {
+                        System.err.println("Invalid progress modifier: " + values[0]);
+                        continue;
+                    }
+
+                    final ProgressActionType action = ProgressActionType.TYPES.get(first.charAt(0));
+                    if (action == null) {
+                        System.err.println("Unknown progress modifier: " + first.charAt(0));
+                        continue;
+                    }
+
+                    action.acceptor.accept(manager, values[1]);
+                }
+            } else {
+                out.write(line.getBytes(StandardCharsets.UTF_8));
+                out.write('\n');
+            }
+        }
+    }
+}

--- a/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressManager.java
+++ b/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressManager.java
@@ -1,0 +1,32 @@
+package net.neoforged.cliutils.progress;
+
+/**
+ * A manager that changes the progress of a progress bar, to indicate the current progress to users.
+ */
+public interface ProgressManager {
+    /**
+     * Sets the max progress of the manager.
+     */
+    void setMaxProgress(int maxProgress);
+
+    /**
+     * Sets the current progress of the manager.
+     */
+    void setProgress(int progress);
+
+    /**
+     * Sets progress of the manager, based on a fractional value. <br>
+     * Note: this also sets the {@link #setMaxProgress(int)} to {@literal 100}.
+     */
+    void setPercentageProgress(double progress);
+
+    /**
+     * Sets the current step to be shown to the user.
+     */
+    void setStep(String name);
+
+    /**
+     * Sets whether the max progress is known or not. If not, the loading bar will load 'forever'.
+     */
+    void setIndeterminate(boolean indeterminate);
+}

--- a/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressReporter.java
+++ b/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressReporter.java
@@ -7,7 +7,8 @@ import java.text.DecimalFormat;
  * A {@link ProgressManager} that forwards all changes to a {@link ProgressReporter#output print stream}
  * that writes the changes with an ANSI modifier {@value #MODIFIER_KEY}. <br>
  * The ANSI modifier takes the form "\033[{@literal progressmanager};action value". <p>
- * The {@link #getDefault() default reporter} will only be enabled if the {@value #ENABLED_PROPERTY} system property is set to {@code true}.
+ * The {@link #getDefault() default reporter} will only be enabled if the {@value #ENABLED_PROPERTY} system property is set to {@code true},
+ * and will output to {@link System#err}.
  * @see ProgressActionType for the actions
  */
 public class ProgressReporter implements ProgressManager {

--- a/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressReporter.java
+++ b/cli-utils/src/main/java/net/neoforged/cliutils/progress/ProgressReporter.java
@@ -1,0 +1,66 @@
+package net.neoforged.cliutils.progress;
+
+import java.io.PrintStream;
+import java.text.DecimalFormat;
+
+/**
+ * A {@link ProgressManager} that forwards all changes to a {@link ProgressReporter#output print stream}
+ * that writes the changes with an ANSI modifier {@value #MODIFIER_KEY}. <br>
+ * The ANSI modifier takes the form "\033[{@literal progressmanager};action value". <p>
+ * The {@link #getDefault() default reporter} will only be enabled if the {@value #ENABLED_PROPERTY} system property is set to {@code true}.
+ * @see ProgressActionType for the actions
+ */
+public class ProgressReporter implements ProgressManager {
+    public static final String MODIFIER_KEY = "progressmanager";
+    public static final String ENABLED_PROPERTY = "net.neoforged.progressmanager.enabled";
+    private static final DecimalFormat TWO_DECIMALS = new DecimalFormat("#.00");
+
+    protected final boolean enabled;
+    protected final PrintStream output;
+
+    public ProgressReporter(boolean enabled, PrintStream output) {
+        this.enabled = enabled;
+        this.output = output;
+    }
+
+    public static ProgressReporter getDefault() {
+        return new ProgressReporter(Boolean.getBoolean(ENABLED_PROPERTY), System.err);
+    }
+
+    @Override
+    public void setMaxProgress(int maxProgress) {
+        write(ProgressActionType.MAX_PROGRESS, String.valueOf(maxProgress));
+    }
+
+    @Override
+    public void setProgress(int progress) {
+        write(ProgressActionType.PROGRESS, String.valueOf(progress));
+    }
+
+    @Override
+    public void setPercentageProgress(double progress) {
+        write(ProgressActionType.PROGRESS, TWO_DECIMALS.format(progress) + "%");
+    }
+
+    @Override
+    public void setStep(String name) {
+        write(ProgressActionType.STEP, name);
+    }
+
+    @Override
+    public void setIndeterminate(boolean indeterminate) {
+        write(ProgressActionType.INDETERMINATE, String.valueOf(indeterminate));
+    }
+
+    protected void write(ProgressActionType type, String value) {
+        if (!enabled) return;
+
+        try {
+            //noinspection RedundantStringFormatCall
+            output.println(String.format("\033[%s;%s %s",  MODIFIER_KEY, type.identifier, value));
+        } catch (Exception exception) {
+            exception.printStackTrace(System.err);
+            System.err.println("Failed to write progress: " + exception);
+        }
+    }
+}

--- a/cli-utils/src/test/java/net/neoforged/cliutils/test/TestProgressManager.java
+++ b/cli-utils/src/test/java/net/neoforged/cliutils/test/TestProgressManager.java
@@ -5,10 +5,7 @@ import net.neoforged.cliutils.progress.ProgressManager;
 import net.neoforged.cliutils.progress.ProgressReporter;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.StringWriter;
 

--- a/cli-utils/src/test/java/net/neoforged/cliutils/test/TestProgressManager.java
+++ b/cli-utils/src/test/java/net/neoforged/cliutils/test/TestProgressManager.java
@@ -51,6 +51,20 @@ public class TestProgressManager {
         assert suite.out.indeterminate;
     }
 
+    @Test
+    void testWriteIsForwarded() {
+        final TestSuite suite = new TestSuite();
+
+        suite.in.setProgress(10);
+        assert suite.allowedOut.toString().isEmpty();
+
+        suite.stream.println("abcd");
+        assert suite.allowedOut.toString().equals("abcd" + System.lineSeparator());
+
+        suite.stream.println("\033jkas");
+        assert suite.allowedOut.toString().equals("abcd" + System.lineSeparator() + "\033jkas" + System.lineSeparator());
+    }
+
     private static class TestSuite {
         public final ProgressManagerImpl out = new ProgressManagerImpl();
         public final StringWriter allowedOut = new StringWriter();

--- a/cli-utils/src/test/java/net/neoforged/cliutils/test/TestProgressManager.java
+++ b/cli-utils/src/test/java/net/neoforged/cliutils/test/TestProgressManager.java
@@ -1,0 +1,96 @@
+package net.neoforged.cliutils.test;
+
+import net.neoforged.cliutils.progress.ProgressInterceptor;
+import net.neoforged.cliutils.progress.ProgressManager;
+import net.neoforged.cliutils.progress.ProgressReporter;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.StringWriter;
+
+public class TestProgressManager {
+
+    @Test
+    void testStep() {
+        final TestSuite suite = new TestSuite();
+        suite.in.setStep("Doing stuff");
+        assert suite.out.step.equals("Doing stuff");
+        assert suite.allowedOut.toString().isEmpty();
+    }
+
+    @Test
+    void testMaxProgress() {
+        final TestSuite suite = new TestSuite();
+        suite.in.setMaxProgress(10);
+        assert suite.out.maxProgress == 10;
+    }
+
+    @Test
+    void testPercentageProgress() {
+        final TestSuite suite = new TestSuite();
+        suite.in.setPercentageProgress(0.11);
+        assert suite.out.maxProgress == 100;
+        assert suite.out.progress == 11;
+    }
+
+    @Test
+    void testProgress() {
+        final TestSuite suite = new TestSuite();
+        suite.in.setProgress(145);
+        assert suite.out.progress == 145;
+    }
+
+    @Test
+    void testIndeterminate() {
+        final TestSuite suite = new TestSuite();
+        suite.in.setIndeterminate(true);
+        assert suite.out.indeterminate;
+    }
+
+    private static class TestSuite {
+        public final ProgressManagerImpl out = new ProgressManagerImpl();
+        public final StringWriter allowedOut = new StringWriter();
+        private final PrintStream stream = new PrintStream(new ProgressInterceptor(new OutputStream() {
+            @Override
+            public void write(int b) {
+                allowedOut.write(b);
+            }
+        }, out));
+        public final ProgressManager in = new ProgressReporter(true, stream);
+    }
+
+    private static class ProgressManagerImpl implements ProgressManager {
+        public int maxProgress = 0, progress = 0;
+        public boolean indeterminate = false;
+        public String step;
+        @Override
+        public void setMaxProgress(int maxProgress) {
+            this.maxProgress = maxProgress;
+        }
+
+        @Override
+        public void setProgress(int progress) {
+            this.progress = progress;
+        }
+
+        @Override
+        public void setPercentageProgress(double progress) {
+            if (maxProgress != 100) setMaxProgress(100);
+            setProgress((int) (progress * 100));
+        }
+
+        @Override
+        public void setStep(String name) {
+            this.step = name;
+        }
+
+        @Override
+        public void setIndeterminate(boolean indeterminate) {
+            this.indeterminate = indeterminate;
+        }
+    }
+}

--- a/jarsplitter/build.gradle
+++ b/jarsplitter/build.gradle
@@ -1,6 +1,9 @@
+evaluationDependsOn(':cli-utils')
+
 dependencies {
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'net.neoforged:srgutils:1.0.0'
+    implementation project(':cli-utils')
 }
 
 application {

--- a/jarsplitter/src/main/java/net/neoforged/jarsplitter/ConsoleTool.java
+++ b/jarsplitter/src/main/java/net/neoforged/jarsplitter/ConsoleTool.java
@@ -11,13 +11,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -26,12 +30,15 @@ import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import net.neoforged.cliutils.progress.ProgressManager;
+import net.neoforged.cliutils.progress.ProgressReporter;
 import net.neoforged.srgutils.IMappingFile;
 
 public class ConsoleTool {
     private static final OutputStream NULL_OUTPUT = new OutputStream() {
-        @Override public void write(int b) throws IOException {}
+        @Override public void write(int b) {}
     };
+    private static final ProgressManager PROGRESS = ProgressReporter.getDefault();
 
     public static void main(String[] args) throws IOException {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT")); //Fix Java stupidity that causes timestamps in zips to depend on user's timezone!
@@ -90,7 +97,11 @@ public class ConsoleTool {
             }
 
             log("Splitting: ");
-            try (ZipInputStream zinput = new ZipInputStream(new FileInputStream(input));
+            final int fileAmount = getCountInZip(input);
+            PROGRESS.setMaxProgress(fileAmount);
+
+            int amount = 0;
+            try (ZipInputStream zinput = new ZipInputStream(Files.newInputStream(input.toPath()));
                  ZipOutputStream zslim = new ZipOutputStream(slim == null ? NULL_OUTPUT : new FileOutputStream(slim));
                  ZipOutputStream zdata = new ZipOutputStream(data == null ? NULL_OUTPUT : new FileOutputStream(data));
                  ZipOutputStream zextra = new ZipOutputStream(extra == null ? NULL_OUTPUT : new FileOutputStream(extra))) {
@@ -101,18 +112,23 @@ public class ConsoleTool {
                        String key = entry.getName().substring(0, entry.getName().length() - 6); //String .class
 
                        if (whitelist.isEmpty() || whitelist.contains(key)) {
-                           log("  Slim  " + entry.getName());
                            copy(entry, zinput, zslim);
                        } else {
-                           log("  Extra " + entry.getName());
                            copy(entry, zinput, zextra);
                        }
                    } else {
                        log("  Data  " + entry.getName());
                        copy(entry, zinput, merge ? zextra : zdata);
                    }
+
+                   amount++;
+                   if (amount % 100 == 0) {
+                       PROGRESS.setProgress(amount);
+                   }
                }
             }
+            PROGRESS.setProgress(fileAmount);
+
             writeCache(slim, inputSha, srgSha);
             writeCache(data, inputSha, srgSha);
             writeCache(extra, inputSha, srgSha);
@@ -177,7 +193,7 @@ public class ConsoleTool {
         System.out.println(message);
     }
 
-    private static String sha1(Set<String> data) throws IOException {
+    private static String sha1(Set<String> data) {
         if (data.isEmpty())
             return "empty";
 
@@ -201,14 +217,21 @@ public class ConsoleTool {
 
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-1");
-            try(InputStream input = new FileInputStream(path)) {
-                int read = -1;
+            try (InputStream input = Files.newInputStream(path.toPath())) {
+                int read;
                 while ((read = input.read(BUFFER)) != -1)
                     digest.update(BUFFER, 0, read);
                 return new BigInteger(1, digest.digest()).toString(16);
             }
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static int getCountInZip(File path) throws IOException {
+        try (FileSystem fs = FileSystems.newFileSystem(path.toPath(), null); final Stream<Path> count = Files.find(fs.getPath("."), Integer.MAX_VALUE, (p, basicFileAttributes) -> Files.isRegularFile(p))) {
+            final long c = count.count();
+            return c > (long) Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) c;
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
+include(':cli-utils')
 include(':jarsplitter')

--- a/src/main/java/net/neoforged/installertools/BundlerExtract.java
+++ b/src/main/java/net/neoforged/installertools/BundlerExtract.java
@@ -89,6 +89,8 @@ public class BundlerExtract extends Task {
                 FileList libraries = FileList.read(fs.getPath("META-INF", "libraries.list"));
                 FileList versions = FileList.read(fs.getPath("META-INF", "versions.list"));
 
+                int amount = 0;
+
                 if (jarOnly) {
                     FileList.Entry entry = null;
                     for (FileList.Entry e : versions.entries) {
@@ -106,16 +108,24 @@ public class BundlerExtract extends Task {
                     if (output.exists() && output.isFile())
                         error("Can not extract to " + output + " as it is a file, not a directory");
 
-                    for (FileList.Entry entry : libraries.entries)
+                    PROGRESS.setMaxProgress(libraries.entries.size());
+                    for (FileList.Entry entry : libraries.entries) {
                         extractFile("libraries", fs, entry, new File(output, entry.path));
+                        PROGRESS.setProgress(++amount);
+                    }
                 } else if (all) {
                     if (output.exists() && output.isFile())
                         error("Can not extract to " + output + " as it is a file, not a directory");
 
-                    for (FileList.Entry entry : libraries.entries)
+                    PROGRESS.setMaxProgress(libraries.entries.size() + versions.entries.size());
+                    for (FileList.Entry entry : libraries.entries) {
                         extractFile("libraries", fs, entry, new File(output, "libraries/" + entry.path));
-                    for (FileList.Entry entry : versions.entries)
+                        PROGRESS.setProgress(++amount);
+                    }
+                    for (FileList.Entry entry : versions.entries) {
                         extractFile("versions", fs, entry, new File(output, "versions/" + entry.path));
+                        PROGRESS.setProgress(++amount);
+                    }
                 } else {
                     error("Must specify either --jar only, or --all");
                 }

--- a/src/main/java/net/neoforged/installertools/DownloadMojmaps.java
+++ b/src/main/java/net/neoforged/installertools/DownloadMojmaps.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Files;
 
 public class DownloadMojmaps extends Task {
@@ -76,7 +77,8 @@ public class DownloadMojmaps extends Task {
                     if (download == null || download.url == null)
                         error("Missing download info for " + side + " mappings");
 
-                    Files.copy(download.url.openStream(), output.toPath());
+                    final URLConnection connection = download.url.openConnection();
+                    Files.copy(PROGRESS.wrapDownload(connection), output.toPath());
                     log("Downloaded Mojang mappings for " + mcversion);
                 }
             }

--- a/src/main/java/net/neoforged/installertools/Task.java
+++ b/src/main/java/net/neoforged/installertools/Task.java
@@ -18,9 +18,13 @@
  */
 package net.neoforged.installertools;
 
+import net.neoforged.cliutils.progress.ProgressReporter;
+
 import java.io.IOException;
 
 public abstract class Task {
+    protected static final ProgressReporter PROGRESS = ProgressReporter.getDefault();
+
     public abstract void process(String[] args) throws IOException;
 
     protected void error(String message) {


### PR DESCRIPTION
This PR adds a `cli-utils` project that currently holds progress reporting utilities.  
This progress reporting is based off a special ANSI `\033[progressmanager;` code that is printed to serr in order to report when steps progress and how much they have left to go through.