### PR TITLE
Setup maven central publishing

### DIFF
--- a/.github/workflows/publish-prs.yml
+++ b/.github/workflows/publish-prs.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   publish-prs:
-    if: true
+    if: false # Option not enabled when the workflows were generated
     uses: neoforged/actions/.github/workflows/publish-prs.yml@main
     with:
       artifact_base_path: net/neoforged/installertools/

--- a/.github/workflows/publish-prs.yml
+++ b/.github/workflows/publish-prs.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   publish-prs:
-    if: false # Option not enabled when the workflows were generated
+    if: true
     uses: neoforged/actions/.github/workflows/publish-prs.yml@main
     with:
       artifact_base_path: net/neoforged/installertools/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       java: 8
       pre_gradle_tasks: test
-      gradle_tasks: publish 
+      gradle_tasks: publish closeAndReleaseSonatypeStagingRepository
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       MAVEN_USER: ${{ secrets.MAVEN_USER }}
@@ -25,4 +25,5 @@ jobs:
       GPG_SUBKEY: ${{ secrets.GPG_SUBKEY }}
       GPG_SUBKEY_ID: ${{ secrets.GPG_SUBKEY_ID }}
       GPG_SUBKEY_PASSWORD: ${{ secrets.GPG_SUBKEY_PASSWORD }}
-      
+      SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.neoforged.gradleutils.PomUtilsExtension.License
 
 plugins {
   id 'org.cadixdev.licenser' version '0.6.1'
@@ -48,6 +49,10 @@ allprojects {
     }
 }
 
+gradleutils {
+    setupCentralPublishing()
+}
+
 base {
     archivesName = 'installertools'
 }
@@ -90,16 +95,9 @@ allprojects {
         publications {
             withType(MavenPublication).configureEach {
                 it.pom {
-                    rootProject.pomUtils.githubRepo(it, 'InstallerTools')
-
-                    licenses {
-                        license {
-                            name = 'LGPLv2.1'
-                            url = 'https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt'
-                        }
-                    }
-
-                    rootProject.pomUtils.neoForgedDeveloper(it)
+                    pomUtils.githubRepo(it, 'InstallerTools')
+                    pomUtils.license(it, License.LGPL_v2)
+                    pomUtils.neoForgedDeveloper(it)
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ allprojects {
 }
 
 gradleutils {
+    setupSigning()
     setupCentralPublishing()
 }
 


### PR DESCRIPTION
Sets up maven central publishing; once this is merged the versions depended on by ART can be bumped, so that it's dependencies will be on central