### PR TITLE
Shrink binpatches by remapping constant pool indices

### DIFF
--- a/binarypatcher/build.gradle
+++ b/binarypatcher/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation(libs.jopt)
     implementation(libs.lzma)
     implementation(libs.xdelta)
+    implementation(libs.asm)
     implementation(project(':cli-utils'))
 
     testImplementation(libs.bundles.junit)

--- a/binarypatcher/src/main/java/net/neoforged/binarypatcher/ConsoleTool.java
+++ b/binarypatcher/src/main/java/net/neoforged/binarypatcher/ConsoleTool.java
@@ -27,6 +27,7 @@ public class ConsoleTool {
         OptionSpec<String> prefixO = parser.accepts("prefix").withRequiredArg();
         OptionSpec<Void> packO = parser.accepts("pack200");
         OptionSpec<Void> legacyO = parser.accepts("legacy", "Uses the legacy patch header format, also implies --pack200. NOT RECOMENDED.");
+        OptionSpec<Void> minimizeO = parser.accepts("minimize");
 
         // Create arguments
         OptionSpec<File> createO = parser.acceptsAll(Arrays.asList("dirty", "create")).withRequiredArg().ofType(File.class);
@@ -44,6 +45,7 @@ public class ConsoleTool {
             File output = options.valueOf(outputO).getAbsoluteFile();
             boolean legacy = options.has(legacyO);
             boolean pack200 = legacy || options.has(packO);
+            boolean minimizePatches = options.has(minimizeO);
 
             if (output.exists() && !output.delete())
                 err("Could not delete output file: " + output);
@@ -66,8 +68,9 @@ public class ConsoleTool {
                 log("  Output:  " + output);
                 log("  Pack200: " + pack200);
                 log("  Legacy:    " + legacy);
+                log("  Minimize patches: " + minimizePatches);
 
-                Generator gen = new Generator(output).pack200(pack200).legacy(legacy);
+                Generator gen = new Generator(output).pack200(pack200).legacy(legacy).minimizePatches(minimizePatches);
 
                 if (clean.size() > 1 || dirty.size() > 1 || prefixes.size() > 1) {
                     if (clean.size() != dirty.size() || dirty.size() != prefixes.size()) {

--- a/binarypatcher/src/main/java/net/neoforged/binarypatcher/Generator.java
+++ b/binarypatcher/src/main/java/net/neoforged/binarypatcher/Generator.java
@@ -47,6 +47,7 @@ public class Generator {
     private final List<PatchSet> sets = new ArrayList<>();
     private boolean pack200 = false;
     private boolean legacy = false;
+    private boolean minimizePatches = false;
 
     public Generator(File output) {
         this.output = output;
@@ -82,6 +83,15 @@ public class Generator {
 
     public Generator legacy(boolean value) {
         this.legacy = value;
+        return this;
+    }
+
+    public Generator minimizePatches() {
+        return this.minimizePatches(true);
+    }
+
+    public Generator minimizePatches(boolean value) {
+        this.minimizePatches = value;
         return this;
     }
 
@@ -250,7 +260,7 @@ public class Generator {
         else
             log("  Processing " + srg + "(" + obf + ")");
 
-        Patch patch = Patch.from(obf, srg, clean, dirty);
+        Patch patch = Patch.from(obf, srg, clean, dirty, this.minimizePatches);
         log("    Clean: " + Integer.toHexString(patch.checksum(clean)) + " Dirty: " + Integer.toHexString(patch.checksum(dirty)));
         return patch.toBytes(this.legacy);
     }

--- a/binarypatcher/src/main/java/net/neoforged/binarypatcher/Patch.java
+++ b/binarypatcher/src/main/java/net/neoforged/binarypatcher/Patch.java
@@ -33,8 +33,11 @@ public class Patch {
         this.data = data;
     }
 
-    public static Patch from(String obf, String srg, byte[] clean, byte[] dirty) throws IOException {
-        byte[] diff = dirty.length == 0 ? EMPTY_DATA : DELTA.compute(clean, shrinkDirtyForPatch(clean, dirty));
+    public static Patch from(String obf, String srg, byte[] clean, byte[] dirty, boolean minimizePatch) throws IOException {
+        if (minimizePatch) {
+            dirty = shrinkDirtyForPatch(clean, dirty);
+        }
+        byte[] diff = dirty.length == 0 ? EMPTY_DATA : DELTA.compute(clean, dirty);
         int checksum = clean.length == 0 ? 0 : adlerHash(clean);
         return new Patch(obf, srg, clean.length != 0, checksum, diff);
     }

--- a/binarypatcher/src/main/java/net/neoforged/binarypatcher/Patch.java
+++ b/binarypatcher/src/main/java/net/neoforged/binarypatcher/Patch.java
@@ -40,6 +40,9 @@ public class Patch {
     }
 
     private static byte[] shrinkDirtyForPatch(byte[] clean, byte[] dirty) {
+        if (clean.length == 0) {
+            return dirty;
+        }
         final ClassReader cleanReader = new ClassReader(clean);
         final ClassReader dirtyReader = new ClassReader(dirty);
         final ClassWriter writer = new ClassWriter(cleanReader, 0);

--- a/binarypatcher/src/main/java/net/neoforged/binarypatcher/Patch.java
+++ b/binarypatcher/src/main/java/net/neoforged/binarypatcher/Patch.java
@@ -12,6 +12,8 @@ import java.io.InputStream;
 import java.util.zip.Adler32;
 
 import com.nothome.delta.Delta;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
 
 public class Patch {
     private static final byte[] EMPTY_DATA = new byte[0];
@@ -32,9 +34,17 @@ public class Patch {
     }
 
     public static Patch from(String obf, String srg, byte[] clean, byte[] dirty) throws IOException {
-        byte[] diff = dirty.length == 0 ? EMPTY_DATA : DELTA.compute(clean, dirty);
+        byte[] diff = dirty.length == 0 ? EMPTY_DATA : DELTA.compute(clean, shrinkDirtyForPatch(clean, dirty));
         int checksum = clean.length == 0 ? 0 : adlerHash(clean);
         return new Patch(obf, srg, clean.length != 0, checksum, diff);
+    }
+
+    private static byte[] shrinkDirtyForPatch(byte[] clean, byte[] dirty) {
+        final ClassReader cleanReader = new ClassReader(clean);
+        final ClassReader dirtyReader = new ClassReader(dirty);
+        final ClassWriter writer = new ClassWriter(cleanReader, 0);
+        dirtyReader.accept(writer, 0);
+        return writer.toByteArray();
     }
 
     public byte[] toBytes() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ dependencyResolutionManagement {
             library('jopt', 'net.sf.jopt-simple:jopt-simple:5.0.4')
             library('lzma', 'com.github.jponge:lzma-java:1.3')
             library('xdelta', 'com.nothome:javaxdelta:2.0.1')
+            library('asm', 'org.ow2.asm:asm:9.7')
         }
     }
 }


### PR DESCRIPTION
Patch files are often very large because constant pool entries inserted in the middle cause any methods using subsequent entries to be unnecessarily patched. Copying the constant pool from the original class, then using that to rewrite the new class results in a drastically reduced patch size (60% savings in the case of `Minecraft.class` in NeoForge).