### PR TITLE
Bump ASM to 9.7 to support remapping of later Java versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation(libs.jopt)
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'de.siegmar:fastcsv:2.0.0'
-    implementation 'org.ow2.asm:asm-commons:9.3'
+    implementation(libs.asm.commons)
     implementation project(':cli-utils')
 
     testImplementation(libs.bundles.junit)

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
             library('lzma', 'com.github.jponge:lzma-java:1.3')
             library('xdelta', 'com.nothome:javaxdelta:2.0.1')
             library('asm', 'org.ow2.asm:asm:9.7')
+            library('asm-commons', 'org.ow2.asm:asm-commons:9.7')
         }
     }
 }


### PR DESCRIPTION
We're using installertools SRG remapper for legacy MDG. While legacy Forge versions may require the use of Java 17, some libraries embed `META-INF/versions/` files that are newer than that, and the remapper will fail for those libraries.