### PR TITLE
Modernize Gradle build

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -19,5 +19,5 @@ jobs:
   build:
     uses: neoforged/actions/.github/workflows/build-prs.yml@main
     with:
-      java: 8
+      java: 21
       gradle_tasks: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     uses: neoforged/actions/.github/workflows/gradle-publish.yml@main
     with:
-      java: 8
+      java: 21
       pre_gradle_tasks: test
       gradle_tasks: publish closeAndReleaseSonatypeStagingRepository
     secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.gradle/
+/buildSrc/.gradle/
 /.idea/
 build/
 /repo/

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 build/
 /repo/
 /.settings/
-/bin/
-/out/
+bin/
+out/
 .classpath
 .project
 *.lzma

--- a/LICENSE-header.txt
+++ b/LICENSE-header.txt
@@ -1,5 +1,5 @@
 InstallerTools
-Copyright (c) 2019-2021.
+Copyright (c) 2019-2025.
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/binarypatcher/build.gradle
+++ b/binarypatcher/build.gradle
@@ -1,8 +1,10 @@
+
+apply plugin : ProjectDefaultsPlugin
+apply plugin : CliToolPlugin
+
 application {
     mainClass = 'net.neoforged.binarypatcher.ConsoleTool'
 }
-
-evaluationDependsOn(':cli-utils')
 
 dependencies {
     implementation(libs.srgutils)
@@ -22,7 +24,7 @@ test {
 publishing {
     publications.register('mavenJava', MavenPublication) {
         from components.java
-        artifactId = 'binarypatcher'
+
         pom {
             name = 'Binary Patcher'
             description = 'Creates and applies binary patches for jar files at the class level.'

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ license {
 dependencies {
     implementation(libs.srgutils)
     implementation(libs.jopt)
-    implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'de.siegmar:fastcsv:2.0.0'
+    implementation(libs.gson)
+    implementation(libs.fastcsv)
     implementation(libs.asm.commons)
     implementation project(':cli-utils')
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,53 +2,13 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import net.neoforged.gradleutils.PomUtilsExtension.License
 
 plugins {
-  id 'org.cadixdev.licenser' version '0.6.1'
-  id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
-  id 'net.neoforged.gradleutils' version '3.0.0-alpha.10' apply false
+  id 'net.neoforged.licenser'
+  id 'com.gradleup.shadow' apply false
+  id 'net.neoforged.gradleutils' apply false
 }
 
-allprojects {
-    apply plugin: 'application'
-    apply plugin: 'maven-publish'
-    apply plugin: 'java-library'
-    apply plugin: 'net.neoforged.gradleutils'
-    if (project.name != 'cli-utils' && project.name != 'problems-api') {
-        apply plugin: 'com.github.johnrengelman.shadow'
-    }
-
-    group = 'net.neoforged.installertools'
-    java {
-        withJavadocJar()
-        withSourcesJar()
-        toolchain.languageVersion = JavaLanguageVersion.of(8)
-    }
-
-    repositories {
-        mavenCentral()
-    }
-
-    gradleutils.version {
-        branches.suffixBranch()
-    }
-
-    version = gradleutils.version
-    println("${project.name} version: " + version)
-
-    gradleutils.setupSigning(signAllPublications: true)
-
-    tasks.named('jar', Jar).configure {
-        manifest.attributes('Implementation-Version': project.version)
-        if (application.mainClass.getOrNull()) {
-            manifest.attributes('Main-Class': application.mainClass.get())
-        }
-    }
-
-    if (project.name != 'cli-utils' && project.name != 'problems-api') {
-        tasks.named('shadowJar', ShadowJar).configure {
-            archiveClassifier = 'fatjar'
-        }
-    }
-}
+apply plugin : ProjectDefaultsPlugin
+apply plugin : CliToolPlugin
 
 gradleutils {
     setupSigning()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation 'dev.lukebemish.immaculate:dev.lukebemish.immaculate.gradle.plugin:0.1.8'
+    implementation 'net.neoforged.gradleutils:net.neoforged.gradleutils.gradle.plugin:4.1.0'
+}
+
+repositories {
+    gradlePluginPortal()
+}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    implementation 'dev.lukebemish.immaculate:dev.lukebemish.immaculate.gradle.plugin:0.1.8'
     implementation 'net.neoforged.gradleutils:net.neoforged.gradleutils.gradle.plugin:4.1.0'
 }
 

--- a/buildSrc/src/main/java/CliToolPlugin.java
+++ b/buildSrc/src/main/java/CliToolPlugin.java
@@ -1,0 +1,29 @@
+import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaApplication;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.api.tasks.bundling.Jar;
+
+import java.util.Map;
+
+public class CliToolPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply("application");
+        project.getPlugins().apply("com.gradleup.shadow");
+
+        project.getTasks().named("shadowJar", AbstractArchiveTask.class, task -> {
+            task.getArchiveClassifier().set("fatjar");
+        });
+
+        var applicationExtension = project.getExtensions().getByType(JavaApplication.class);
+        project.getTasks().named("jar", Jar.class, task -> {
+            var mainClass = applicationExtension.getMainClass().getOrNull();
+            if (mainClass == null) {
+                throw new InvalidUserCodeException("No application main class was set when the Jar task was configured.");
+            }
+            task.getManifest().attributes(Map.of("Main-Class", mainClass));
+        });
+    }
+}

--- a/buildSrc/src/main/java/ProjectDefaultsPlugin.java
+++ b/buildSrc/src/main/java/ProjectDefaultsPlugin.java
@@ -1,0 +1,41 @@
+import net.neoforged.gradleutils.GradleUtilsExtension;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+
+import java.util.Map;
+
+public class ProjectDefaultsPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        var plugins = project.getPlugins();
+        plugins.apply("maven-publish");
+        plugins.apply("java-library");
+        plugins.apply("net.neoforged.gradleutils");
+
+        project.setGroup("net.neoforged.installertools");
+
+        var java = project.getExtensions().getByType(JavaPluginExtension.class);
+        java.withJavadocJar();
+        java.withSourcesJar();
+
+        // We must support Java 8 due to it being the minimum supported version of the installer
+        java.getToolchain().getLanguageVersion().set(JavaLanguageVersion.of(8));
+
+        var gradleUtilsExtension = project.getExtensions().getByType(GradleUtilsExtension.class);
+        var projectVersion = gradleUtilsExtension.getVersion();
+        project.setVersion(projectVersion);
+
+        project.getLogger().lifecycle("{} version: {}", project.getName(), projectVersion);
+
+        gradleUtilsExtension.setupSigning(project, true);
+
+        var jarTask = project.getTasks().named("jar", Jar.class);
+        jarTask.configure(task -> {
+            var manifest = task.getManifest();
+            manifest.attributes(Map.of("Implementation-Version", projectVersion.toString()));
+        });
+    }
+}

--- a/cli-utils/build.gradle
+++ b/cli-utils/build.gradle
@@ -1,3 +1,6 @@
+
+apply plugin : ProjectDefaultsPlugin
+
 dependencies {
     testImplementation(libs.bundles.junit)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# We cannot use the configuration cache due to the Nexus Publishing Plugin
+# See https://github.com/gradle-nexus/publish-plugin/issues/221
+# org.gradle.configuration-cache=true

--- a/jarsplitter/build.gradle
+++ b/jarsplitter/build.gradle
@@ -1,4 +1,10 @@
-evaluationDependsOn(':cli-utils')
+
+apply plugin : ProjectDefaultsPlugin
+apply plugin : CliToolPlugin
+
+application {
+    mainClass = 'net.neoforged.jarsplitter.ConsoleTool'
+}
 
 dependencies {
     implementation(libs.jopt)
@@ -6,15 +12,9 @@ dependencies {
     implementation project(':cli-utils')
 }
 
-application {
-    mainClass = 'net.neoforged.jarsplitter.ConsoleTool'
-}
-
 publishing {
     publications.register('mavenJava', MavenPublication) {
         from components.java
-
-        artifactId = 'jarsplitter'
 
         pom {
             name = 'Jar Splitter'

--- a/problems-api/build.gradle
+++ b/problems-api/build.gradle
@@ -1,7 +1,9 @@
 
+apply plugin : ProjectDefaultsPlugin
+
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.9'
-    compileOnly "org.jetbrains:annotations:26.0.1"
+    implementation(libs.gson)
+    compileOnly(libs.jetbrains.annotations)
 }
 
 publishing {

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@ pluginManagement {
     }
     repositories {
         gradlePluginPortal()
+        // Required for licenser
         maven {
             name = 'NeoForged'
             url = 'https://maven.neoforged.net/releases/'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,33 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+import org.gradle.api.initialization.resolve.RulesMode
+
+pluginManagement {
+    plugins {
+        id 'net.neoforged.licenser' version '0.7.5'
+        id 'com.gradleup.shadow' version '8.3.6'
+        id 'net.neoforged.gradleutils' version '4.1.0'
+    }
+    repositories {
+        gradlePluginPortal()
+        maven {
+            name = 'NeoForged'
+            url = 'https://maven.neoforged.net/releases/'
+        }
+    }
+}
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
-            version('junit', '5.10.0')
+            version('junit', '5.13.1')
             library('junit-api', 'org.junit.jupiter', 'junit-jupiter-api').versionRef('junit')
             library('junit-engine', 'org.junit.jupiter', 'junit-jupiter-engine').versionRef('junit')
-            library('junit-platform-launcher', 'org.junit.platform:junit-platform-launcher:1.10.0')
-            library('assert4j', 'org.assertj:assertj-core:3.25.1')
+            library('junit-platform-launcher', 'org.junit.platform:junit-platform-launcher:1.13.1')
+            library('assert4j', 'org.assertj:assertj-core:3.27.3')
             bundle('junit', ['junit-engine', 'junit-platform-launcher', 'junit-api', 'assert4j'])
 
             library('srgutils', 'net.neoforged:srgutils:1.0.0')
@@ -14,7 +36,17 @@ dependencyResolutionManagement {
             library('xdelta', 'com.nothome:javaxdelta:2.0.1')
             library('asm', 'org.ow2.asm:asm:9.7')
             library('asm-commons', 'org.ow2.asm:asm-commons:9.7')
+            library('gson', 'com.google.code.gson:gson:2.8.9')
+            library('jetbrains-annotations', 'org.jetbrains:annotations:26.0.1')
         }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+    rulesMode = RulesMode.FAIL_ON_PROJECT_RULES
+    repositories {
+        mavenCentral()
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,6 +37,7 @@ dependencyResolutionManagement {
             library('asm', 'org.ow2.asm:asm:9.7')
             library('asm-commons', 'org.ow2.asm:asm-commons:9.7')
             library('gson', 'com.google.code.gson:gson:2.8.9')
+            library('fastcsv', 'de.siegmar:fastcsv:2.0.0')
             library('jetbrains-annotations', 'org.jetbrains:annotations:26.0.1')
         }
     }

--- a/src/main/java/net/neoforged/installertools/BundlerExtract.java
+++ b/src/main/java/net/neoforged/installertools/BundlerExtract.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/ChainMappings.java
+++ b/src/main/java/net/neoforged/installertools/ChainMappings.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/ConsoleTool.java
+++ b/src/main/java/net/neoforged/installertools/ConsoleTool.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/CreateDirectory.java
+++ b/src/main/java/net/neoforged/installertools/CreateDirectory.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/CreateParents.java
+++ b/src/main/java/net/neoforged/installertools/CreateParents.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/DownloadMojmaps.java
+++ b/src/main/java/net/neoforged/installertools/DownloadMojmaps.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/ExtractFiles.java
+++ b/src/main/java/net/neoforged/installertools/ExtractFiles.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/ExtractInheritance.java
+++ b/src/main/java/net/neoforged/installertools/ExtractInheritance.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/McpData.java
+++ b/src/main/java/net/neoforged/installertools/McpData.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/MergeMappings.java
+++ b/src/main/java/net/neoforged/installertools/MergeMappings.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/SrgMcpRenamer.java
+++ b/src/main/java/net/neoforged/installertools/SrgMcpRenamer.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/Task.java
+++ b/src/main/java/net/neoforged/installertools/Task.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/Tasks.java
+++ b/src/main/java/net/neoforged/installertools/Tasks.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/util/Artifact.java
+++ b/src/main/java/net/neoforged/installertools/util/Artifact.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/util/HashFunction.java
+++ b/src/main/java/net/neoforged/installertools/util/HashFunction.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/util/ManifestJson.java
+++ b/src/main/java/net/neoforged/installertools/util/ManifestJson.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/util/Utils.java
+++ b/src/main/java/net/neoforged/installertools/util/Utils.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/neoforged/installertools/util/VersionJson.java
+++ b/src/main/java/net/neoforged/installertools/util/VersionJson.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/neoforged/installertools/MergeMappingsTest.java
+++ b/src/test/java/net/neoforged/installertools/MergeMappingsTest.java
@@ -1,6 +1,6 @@
 /*
  * InstallerTools
- * Copyright (c) 2019-2021.
+ * Copyright (c) 2019-2025.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/zipinject/build.gradle
+++ b/zipinject/build.gradle
@@ -1,10 +1,14 @@
-dependencies {
-    implementation(libs.jopt)
-    testImplementation(libs.bundles.junit)
-}
+
+apply plugin : ProjectDefaultsPlugin
+apply plugin : CliToolPlugin
 
 application {
     mainClass = 'net.neoforged.zipinject.ConsoleTool'
+}
+
+dependencies {
+    implementation(libs.jopt)
+    testImplementation(libs.bundles.junit)
 }
 
 test {
@@ -14,8 +18,6 @@ test {
 publishing {
     publications.register('mavenJava', MavenPublication) {
         from components.java
-
-        artifactId = 'zipinject'
 
         pom {
             name = 'Zip Inject'


### PR DESCRIPTION
- Move all dependencies to the version catalog that already exists and update several of them
- Remove the use of `allprojects`, use 2 plugins in `buildSrc` instead
- Switch to the gradleup version of the shadow plugin
- Switch to the neo fork of licenser
- Switch to repository management and plugin management in settings.gradle

This would support configuration cache, I believe, if it wasn't for the Nexus publishing plugin pulled in by gradleutils.