### PR TITLE
Add API to apply patches from input streams

### DIFF
--- a/src/main/java/net/neoforged/installertools/InterfaceInjection.java
+++ b/src/main/java/net/neoforged/installertools/InterfaceInjection.java
@@ -1,3 +1,21 @@
+/*
+ * InstallerTools
+ * Copyright (c) 2019-2025.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package net.neoforged.installertools;
 
 import com.google.gson.Gson;

--- a/src/main/java/net/neoforged/installertools/SuperinterfaceSignatureConverter.java
+++ b/src/main/java/net/neoforged/installertools/SuperinterfaceSignatureConverter.java
@@ -1,3 +1,21 @@
+/*
+ * InstallerTools
+ * Copyright (c) 2019-2025.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package net.neoforged.installertools;
 
 import org.objectweb.asm.signature.SignatureReader;

--- a/src/test/java/net/neoforged/installertools/InterfaceInjectionTest.java
+++ b/src/test/java/net/neoforged/installertools/InterfaceInjectionTest.java
@@ -1,3 +1,21 @@
+/*
+ * InstallerTools
+ * Copyright (c) 2019-2025.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package net.neoforged.installertools;
 
 import com.google.gson.Gson;

--- a/src/test/java/net/neoforged/installertools/SuperinterfaceSignatureConverterTest.java
+++ b/src/test/java/net/neoforged/installertools/SuperinterfaceSignatureConverterTest.java
@@ -1,3 +1,21 @@
+/*
+ * InstallerTools
+ * Copyright (c) 2019-2025.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package net.neoforged.installertools;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
To avoid having to extract patches in auto-install.

Also: Remove global timezone changes from applier.